### PR TITLE
add Info for 2,4 ghz and 5 ghz Clients

### DIFF
--- a/respondd_client.py
+++ b/respondd_client.py
@@ -46,6 +46,8 @@ class NodeInfo:
 class ClientInfo:
     total: int
     wifi: int
+    wifi24: int
+    wifi5: int
 
 
 @dataclasses.dataclass
@@ -114,7 +116,7 @@ class ResponddClient:
         for ap in aps.accesspoints:
             statistics.append(
                 StatisticsInfo(
-                    clients=ClientInfo(total=ap.client_count, wifi=ap.client_count),
+                    clients=ClientInfo(total=ap.client_count, wifi=ap.client_count, wifi24=ap.client_count24, wifi5=ap.client_count5),
                     uptime=ap.uptime,
                     node_id=ap.mac.replace(":", ""),
                     loadavg=ap.load_avg,

--- a/unifi_respondd.py
+++ b/unifi_respondd.py
@@ -15,6 +15,8 @@ class Accesspoint:
     mac: str
     snmp_location: str
     client_count: int
+    client_count24: int
+    client_count5: int
     latitude: float
     longitude: float
     model: str
@@ -76,11 +78,15 @@ def get_clients_for_site(cfg, site):
 
 
 def get_client_count_for_ap(ap_mac, clients):
-    client_count = 0
+    client5_count = 0
+    client24_count = 0
     for client in clients:
         if client.get("ap_mac", "No mac") == ap_mac:
-            client_count += 1
-    return client_count
+            if client.get("channel", 0) > 14:
+                client5_count += 1
+            else :
+                client24_count += 1
+    return client24_count + client5_count, client24_count, client5_count 
 
 
 def get_location_by_address(address, app):
@@ -101,6 +107,7 @@ def get_infos():
         clients = get_clients_for_site(cfg, site["name"])
         for ap in aps_for_site:
             if ap.get("name", None) is not None:
+                client_count, client_countghz24, client_countghz5 = get_client_count_for_ap(ap.get("mac", None), clients)
                 lat, lon = 0, 0
                 if ap.get("snmp_location", None) is not None:
                     try:
@@ -109,14 +116,16 @@ def get_infos():
                         )
                     except:
                         pass
+
+
                 aps.accesspoints.append(
                     Accesspoint(
                         name=ap.get("name", None),
                         mac=ap.get("mac", None),
                         snmp_location=ap.get("snmp_location", None),
-                        client_count=get_client_count_for_ap(
-                            ap.get("mac", None), clients
-                        ),
+                        client_count=client_count,
+                        client_countghz24=client_countghz24,
+                        client_countghz5=client_countghz5,
                         latitude=float(lat),
                         longitude=float(lon),
                         model=ap.get("model", None),

--- a/unifi_respondd.py
+++ b/unifi_respondd.py
@@ -107,7 +107,7 @@ def get_infos():
         clients = get_clients_for_site(cfg, site["name"])
         for ap in aps_for_site:
             if ap.get("name", None) is not None:
-                client_count, client_countghz24, client_countghz5 = get_client_count_for_ap(ap.get("mac", None), clients)
+                client_count, client_count24, client_count5 = get_client_count_for_ap(ap.get("mac", None), clients)
                 lat, lon = 0, 0
                 if ap.get("snmp_location", None) is not None:
                     try:
@@ -122,8 +122,8 @@ def get_infos():
                         mac=ap.get("mac", None),
                         snmp_location=ap.get("snmp_location", None),
                         client_count=client_count,
-                        client_countghz24=client_countghz24,
-                        client_countghz5=client_countghz5,
+                        client_count24=client_count24,
+                        client_count5=client_count5,
                         latitude=float(lat),
                         longitude=float(lon),
                         model=ap.get("model", None),

--- a/unifi_respondd.py
+++ b/unifi_respondd.py
@@ -116,8 +116,6 @@ def get_infos():
                         )
                     except:
                         pass
-
-
                 aps.accesspoints.append(
                     Accesspoint(
                         name=ap.get("name", None),


### PR DESCRIPTION
respondd_client.py must be testet
i dont know that is right
```python
 clients=ClientInfo(total=ap.client_count, wifi=ap.client_count, wifi24=ap.client_count24, wifi5=ap.client_count5),
```
tried to copy from there: https://github.com/freifunk-gluon/gluon/blob/17731ae8fdf47012b5d2efcb8823f94474411315/package/gluon-respondd/src/respondd-statistics.c#L282-L298


unifi_respondd.py works as expected for me:
![image](https://user-images.githubusercontent.com/5702338/147867669-e56bb9c5-83b0-4c21-8631-0769dcc31aa3.png)
```python
Accesspoints(accesspoints=[Accesspoint(name='AP-Innenhof', mac='24:5a:4c:2c:2f:5a', snmp_location='48.19716559202241, 11.464076615390965', client_count=2, client_count24=1, client_count5=1, latitude=48.1981755, longitude=11.4690596, model='U7MSH', firmware='5.43.56.12784', uptime=277650, contact='chat @t0biii', load_avg=0.01, mem_used=83480576, mem_total=128557056, mem_buffer=0), Accesspoint(name='AP-StraßenSeite', mac='78:45:58:70:5e:50', snmp_location='48.19708847449219, 11.464145841585054', client_count=0, client_count24=0, client_count5=0, latitude=48.1981755, longitude=11.4690596, model='U7MSH', firmware='5.43.56.12784', uptime=1345982, contact='chat @t0biii', load_avg=0.17, mem_used=83603456, mem_total=128557056, mem_buffer=0)]
```